### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ it under the terms of the GNU General Public License version 3.0.
 
 For more information on Licensing - please read the License file located in the repository.
 
-#Summary
+# Summary
 **Block This** is a DNS/VPN based ad blocking & privacy app for Android, that blocks malicious or unwanted internet content by filtering DNS requests and redirecting them to `127.0.0.1 (localhost)`. It uses a dummy VPN client in order to go around the restrictions in Android and change the DNS settings without having root access. The backend behind the app is a DNS based on [PowerDNS](https://www.powerdns.com/) - an open source DNS management software working with [MySQL](https://mysql.com) as a datasource.  
 
-#Contribution
+# Contribution
 If you wish to join the development please drop in a comment at https://forum.block-this.com or email me at me@savageorgiev.com.
 
 Alternatively, you can just make a pull request here.
 
-#Installation
+# Installation
 
 To get the latest release of **Block This**, go to:
 
@@ -36,7 +36,7 @@ appNextApiKey=YOUR_APP_NEXT_API_KEY
 dns1=YOUR_DNS1_IP_ADDRESS
 dns2=YOUR_DNS2_IP_ADDRESS
 ~~~
-#Community
+# Community
 
 If you wish to join the conversation, please visit our official forums at:
 
@@ -46,10 +46,10 @@ or the Google+ community at:
 
   https://plus.google.com/u/0/communities/113434074801403849306
 
-#About
+# About
 
 I created the app for my own convenience as I needed a privacy and ad blocking solution for my Android device, which I did not want to root. The app worked so well for me that I decided to put it on the Play Store. It had a huge success with almost 1 million downloads in just 2 months, but then it was taken down by Google. It is now hosted on my website as an APK. I open source it with the hope to get further developed and supported by the community.
 
-#Contact 
+# Contact 
 
 For any questions or feedback you can contact me at https://savageorgiev.com or email me at me@savageorgiev.com


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
